### PR TITLE
Fix cabal warning

### DIFF
--- a/free-theorems-0.3.2.0/free-theorems.cabal
+++ b/free-theorems-0.3.2.0/free-theorems.cabal
@@ -18,7 +18,7 @@ description:
     may be derived in addition to classical equational results.
 category:       Language
 tested-with: 	GHC==7.6.1
-cabal-version:  >= 1.2.3
+cabal-version:  >= 1.8
 build-type:	Simple
 
 extra-source-files:


### PR DESCRIPTION
> Warning: free-theorems.cabal:50:21: version operators used. To use version operators the package needs to specify at least 'cabal-version: >= 1.8'.
